### PR TITLE
ДЗ №3

### DIFF
--- a/kubernetes-networks/deployment.yaml
+++ b/kubernetes-networks/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-deployment
+  namespace: homework
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web-server
+  template:
+    metadata:
+      labels:
+        app: web-server
+    spec:
+      containers:
+        - name: web-server
+          image: nginx
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /homework
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm /homework/index.html"]
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+      initContainers:
+        - name: init-container
+          image: busybox
+          command: ['sh', '-c', 'echo "Hello, World!" > /init/index.html']
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /init
+      volumes:
+        - name: shared-volume
+          emptyDir: {}
+        - name: nginx-config
+          configMap:
+            name: nginx-config
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: homework
+                    operator: In
+                    values:
+                      - "true"
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-networks/ingress.yaml
+++ b/kubernetes-networks/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: my-ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+    - host: homework.otus
+      http:
+        paths:
+          - path: /homepage
+            pathType: Prefix
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 80
+          - path: /index.html
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: my-service
+                port:
+                  number: 80

--- a/kubernetes-networks/namespace.yaml
+++ b/kubernetes-networks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/nginx.conf
+++ b/kubernetes-networks/nginx.conf
@@ -1,0 +1,7 @@
+server {
+    listen 8000;
+    root /homework;
+    location / {
+        try_files $uri $uri/ =404;
+    }
+}

--- a/kubernetes-networks/nginx.conf
+++ b/kubernetes-networks/nginx.conf
@@ -1,7 +1,0 @@
-server {
-    listen 8000;
-    root /homework;
-    location / {
-        try_files $uri $uri/ =404;
-    }
-}

--- a/kubernetes-networks/service.yaml
+++ b/kubernetes-networks/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  namespace: homework
+spec:
+  selector:
+    app: web-server
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP


### PR DESCRIPTION
# Выполнено ДЗ №3
Основное ДЗ
 - Изменить readiness-пробу в манифесте deployment.yaml из прошлого ДЗ на httpGet, вызывающую URL /index.html
 - Необходимо создать манифест service.yaml, описывающий сервис типа ClusterIP, который будет направлять трафик на поды, управляемые вашим deployment
 - Установить в кластер ingress-контроллер nginx
 - Создать манифест ingress.yaml, в котором будет описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис. В результате запрос http://homework.otus/index.html должен отдавать код html страницы, находящейся в подах
Задание со *
 - Доработать манифест ingress.yaml, описав в нем rewrite-правила так, чтобы обращение по адресу http://homework.otus/homepage форвардилось на http://homework.otus/index.html

## В процессе сделано:
 - Изменена readiness-пробу в манифесте deployment.yaml из прошлого ДЗ на httpGet, вызывающую URL /index.html
 - Создан манифест service.yaml, описывающий сервис типа ClusterIP, который будет направлять трафик на поды, управляемые вашим deployment
 - Установлен в кластер ingress-контроллер nginx
 - Создан манифест ingress.yaml, в котором описан объект типа ingress, направляющий все http запросы к хосту homework.otus на ранее созданный сервис. В результате запрос http://homework.otus/index.html отдает код html страницы, находящейся в подах
 - Доработан манифест ingress.yaml, описав в нем rewrite-правила так, чтобы обращение по адресу http://homework.otus/homepage форвардилось на http://homework.otus/index.html

## Как запустить проект:
 - kubectl apply -f deployment.yaml
 - kubectl apply -f service.yaml
 - kubectl apply -f ingress.yaml

## Как проверить работоспособность:
 - curl http://homework.otus/index.html
 - curl http://homework.otus/homepage

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
 - kubernetes-networks
