### PR TITLE
ДЗ №8

### DIFF
--- a/kubernetes-monitoring/Dockerfile
+++ b/kubernetes-monitoring/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:latest
+
+RUN rm /etc/nginx/conf.d/default.conf
+ADD nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-monitoring/deployment.yaml
+++ b/kubernetes-monitoring/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-custom-stub
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx-custom-stub
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      name: nginx-custom-stub
+      labels:
+        app: nginx-custom-stub
+    spec:
+      containers:
+      - name: nginx-custom-stub
+        image: custom-nginx:0.0.1
+        readinessProbe:
+          httpGet:
+            path: /stub_status
+            port: 8000
+        ports:
+          - containerPort: 8000
+      - name: nginx-prometheus-exporter
+        args:
+          - "--nginx.scrape-uri=http://localhost:8000/stub_status"
+        image: nginx/nginx-prometheus-exporter:1.3.0
+        imagePullPolicy: Never
+        ports:
+          - name: metrics
+            containerPort: 9113
+      nodeSelector:
+        monitoring: "true"

--- a/kubernetes-monitoring/nginx.conf
+++ b/kubernetes-monitoring/nginx.conf
@@ -1,0 +1,21 @@
+server {
+    listen       8000;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    location /stub_status {
+        stub_status on;
+    }
+
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/kubernetes-monitoring/service.yaml
+++ b/kubernetes-monitoring/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-custom-stub
+  labels:
+    app: nginx-custom-stub
+spec:
+  selector:
+    app: nginx-custom-stub
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+      name: http
+    - port: 9113
+      targetPort: 9113
+      name: metrics

--- a/kubernetes-monitoring/serviceMonitor.yaml
+++ b/kubernetes-monitoring/serviceMonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: nginx-custom-stub
+  labels:
+    team: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: nginx-custom-stub
+  endpoints:
+  - path: /metrics
+    port: metrics
+  jobLabel: nginx-custom-stub


### PR DESCRIPTION
# Выполнено ДЗ № 8

 - [x] Основное ДЗ
 Необходимо создать кастомный образ nginx, отдающий свои метрики на определенном endpoint ( пример из офф документации в разделе ссылок) 
 Установить в кластер Prometheus-operator любым удобным вам способом (рекомендуется ставить или по ссылке из офф документации, либо через helm-чарт) 
 Создать deployment запускающий ваш кастомный nginx образ и service для него 
 Настроить запуск nginx prometheus exporter (отдельным подом или в составе пода с nginx – не принципиально) и сконфигурировать его для сбора метрик с nginx 
 Создать манифест serviceMonitor, описывающий сбор метрик с подов, которые вы создали


## В процессе сделано:
 - Собран кстомный образ нгинкс из докер файла
 
![image](https://github.com/user-attachments/assets/564c4f8c-e8e5-451f-ad00-a617926a7004)

Установлен prometheus с помощью helm 
Выставлен параметр 
![image](https://github.com/user-attachments/assets/631acf02-01ec-4f3f-b3cb-aad70414b7be)
Установлен prometheus
helm install -n monitoring prometheus-stack .


## Как запустить проект:

Запустить все ямл файлы, пробросить порты на локалхост 9090 и 8000

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8000/stub_status
 
![image](https://github.com/user-attachments/assets/f938e1ff-f12a-4d8f-a167-76d627032d5b)

 
 http://localhost:9090/targets?search=&scrapePool=
 
![image](https://github.com/user-attachments/assets/51a7d998-0d7b-4ff7-b264-424d1edf92d7)


## PR checklist:
 - [x] Выставлен label с темой домашнего задания
   kubernetes-monitoring