### PR TITLE
ДЗ №11

### DIFF
--- a/kubernetes-vault/consul.yaml
+++ b/kubernetes-vault/consul.yaml
@@ -1,0 +1,2 @@
+server:
+  replicas: 1

--- a/kubernetes-vault/externalsecret.yaml
+++ b/kubernetes-vault/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: otus-extsecret
+  namespace: vault
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: otus-secretstore
+    kind: SecretStore
+  target:
+    name: otus-cred
+    creationPolicy: Owner
+  dataFrom:
+  - extract:
+      key: cred

--- a/kubernetes-vault/otus_policy.hcl
+++ b/kubernetes-vault/otus_policy.hcl
@@ -1,0 +1,3 @@
+path "otus/*" {
+  capabilities = ["read", "list"]
+}

--- a/kubernetes-vault/sa.yaml
+++ b/kubernetes-vault/sa.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: vault-auth
+  namespace: vault
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-auth
+  namespace: vault
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: vault-auth
+  namespace: vault
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: vault-auth
+  name: vault-auth-token
+  namespace: vault
+type: kubernetes.io/service-account-token

--- a/kubernetes-vault/secretstore.yaml
+++ b/kubernetes-vault/secretstore.yaml
@@ -1,0 +1,21 @@
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: otus-secretstore
+  namespace: vault
+spec:
+  retrySettings:
+    maxRetries: 5
+    retryInterval: "10s"
+  provider:
+    vault:
+      server: "http://vault-server.vault.svc.cluster.local:8200"
+      path: "otus"
+      version: "v2"
+      namespace: "vault"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "otus"
+          serviceAccountRef:
+            name: "vault-auth"

--- a/kubernetes-vault/valut.yaml
+++ b/kubernetes-vault/valut.yaml
@@ -1,0 +1,18 @@
+server:
+  ha:
+    enabled: true
+    replicas: 3
+    config: |
+      ui = true
+
+      listener "tcp" {
+        tls_disable = 1
+        address = "[::]:8200"
+        cluster_address = "[::]:8201"
+      }
+      storage "consul" {
+        path = "vault"
+        address = "consul-server.consul.svc.cluster.local:8500"
+      }
+
+      service_registration "kubernetes" {}


### PR DESCRIPTION
# Выполнено ДЗ № 11

 - [х] Основное ДЗ


## В процессе сделано:
 - Разверните managed Kubernetes cluster в Yandex cloud как в предыдущих дз
 - В namespace consul установлен consul из helm-чарта https://github.com/hashicorp/consul-k8s.git с параметрами 3 реплики для сервера
 helm pull oci://registry-1.docker.io/bitnamicharts/consul
 helm upgrade --install consul consul/ --set global.name=consul --create-namespace -n consul -f consul.yaml
![image](https://github.com/user-attachments/assets/bfd65deb-544b-419d-8042-68764734fa51)
- В namespace vault установлен hashicorp vault
helm pull oci://registry-1.docker.io/bitnamicharts/vault
helm install vault vault/ --create-namespace -n vault -f valut.yaml
![image](https://github.com/user-attachments/assets/08b19073-d2d4-4737-9e71-9edc77bc7655)
- Инициализация vault и распечатка с помощью полученного unseal key все поды хранилища
kubectl -n vault exec -it vault-server-0 -- vault operator init
kubectl -n vault exec -it vault-server-0 -- vault operator unseal (на каждом поде)
![image](https://github.com/user-attachments/assets/ae6643b8-3dc0-4735-bc70-ec1886e11dcb)
- Создано хранилище секретов, включена авторизация кубернетис, создан сервис аккаунт, а так же применены политики сохраненные в файле otus_policy.hcl
kubectl -n vault exec -it vault-server-0 -- bash
vault login
vault secrets enable -version=2 -path=otus kv
vault kv put otus/cred username='otus' password='asajkjkahs'
kubectl apply -f sa.yaml
JWT=$(kubectl get secret vault-auth-token -n vault -o go-template='{{ .data.token }}' | base64 --decode)
KUBER_HOST=$(kubectl config view --raw --minify --flatten --output='jsonpath={.clusters[].cluster.server}')
KUBER_CERT=$(kubectl config view --raw --minify --flatten -o jsonpath='{.clusters[].cluster.certificate-authority-data}' | base64 --decode)
kubectl -n vault exec -it vault-server-0 -- vault write auth/kubernetes/config token_reviewer_jwt="$JWT" kubernetes_host="$KUBER_HOST" kubernetes_ca_cert="$KUBER_CERT" disable_local_ca_jwt="true"
kubectl -n vault exec -it vault-server-0 -- vault auth enable kubernetes
kubectl exec -it vault-server-0 -n vault -- vault policy write otus-policy - <<EOF
path "otus/*" {
  capabilities = ["read", "list"]
}
EOF
![image](https://github.com/user-attachments/assets/af3bfdb1-425e-4fe1-a920-274c7d75d0c8)
- Установлен External Secrets Operator из helm-чарта в namespace vault
helm repo add external-secrets https://charts.external-secrets.io/
helm upgrade --install external-secrets external-secrets/external-secrets --create-namespace -n vault

## Как запустить проект:
 - Применить манифесты после предвариельной подготовки выше
  kubectl apply -f secretstore.yaml
 kubectl apply -f externalsecret.yaml
## Как проверить работоспособность:
 kubectl -n vault get secret otus-cred 
![image](https://github.com/user-attachments/assets/43261472-a02d-401f-bd90-26aaf220212f)


## PR checklist:
 - [x] Выставлен label с темой домашнего задания
